### PR TITLE
EINTG-1882 Remove parameters from cart cookie

### DIFF
--- a/theme.liquid
+++ b/theme.liquid
@@ -8,16 +8,20 @@
     function getCookie(cname) {
         var name = cname + "=";
         var ca = document.cookie.split(';');
+        var cookie = undefined;
         for (var i = 0; i < ca.length; i++) {
             var c = ca[i];
             while (c.charAt(0) == ' ') {
                 c = c.substring(1);
             }
             if (c.indexOf(name) == 0) {
-                return c.substring(name.length, c.length);
+                cookie = c.substring(name.length, c.length);
+                break;
             }
         }
-        return undefined;
+        cookie = decodeURIComponent(cookie);
+        cookie = cookie.split('?')[0];
+        return cookie;
     }
 
     var customer = {};


### PR DESCRIPTION
Shopify updated cart cookie value in the store UI, and it now contains an extra stringified parameter.
[Cart cookie value now includes key param — Shopify developer changelog](https://shopify.dev/changelog/cart-cookie-value-now-includes-key-param) (on my pipeline store this was changed on 21.5)

This update is removing all parameters after `?` from the parsed cookie.